### PR TITLE
Force controller & watcher goroutine to start "early"

### DIFF
--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -28,11 +28,15 @@ func main() {
 		log.Fatal("failed to init kinit client : ", err)
 	}
 
+	c := make(chan struct{})
 	go func() {
+		c <- struct{}{}
 		if err := run.WatchConfigMapChanges(ctx, run); err != nil {
 			log.Fatal(err)
 		}
 	}()
+	// Force WatchConfigMapChanges go routines to actually start
+	<-c
 
 	evadapter.MainWithContext(ctx, PACControllerLogKey, adapter.NewEnvConfig, adapter.New(run, kinteract))
 }

--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -25,7 +25,10 @@ func main() {
 		w.WriteHeader(200)
 		_, _ = fmt.Fprint(w, "ok")
 	})
+
+	c := make(chan struct{})
 	go func() {
+		c <- struct{}{}
 		// start the web server on port and accept requests
 		log.Printf("Readiness and health check server listening on port %s", probesPort)
 		// timeout values same as default one from triggers eventlistener
@@ -38,6 +41,7 @@ func main() {
 		}
 		log.Fatal(srv.ListenAndServe())
 	}()
+	<-c
 
 	sharedmain.Main("pac-watcher", reconciler.NewController())
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Should *probably* fix some possible races with the configmap watcher

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
